### PR TITLE
Keyboard keys up down navigation

### DIFF
--- a/force-app/main/default/lwc/lookupLwc/lookupLwc.html
+++ b/force-app/main/default/lwc/lookupLwc/lookupLwc.html
@@ -6,24 +6,32 @@
                <div class="slds-combobox" aria-expanded="false" aria-haspopup="listbox" role="combobox">
                   <div class="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right" role="none">
                      <template if:false={recordselected}>
-                        <input class="slds-input slds-combobox__input" id="combobox-id-1" aria-autocomplete="list" aria-controls="listbox-id-1"
-                           role="textbox" type="text" placeholder="Search..."  onkeyup={onKeyChange} value={selectedValue}/>
+                       <label class="slds-form-element__label" for="text-input-id-1">
+                           <abbr class="slds-required" title="required">* </abbr>{inputLabel}</label>
+                       <div style="position: relative;">
+                           <input class="lookupInput slds-input slds-combobox__input" id="combobox-id-1" aria-autocomplete="list" aria-controls="listbox-id-1"
+                               role="textbox" type="text" placeholder="Search..." onkeyup={onKeyChange} value={selectedValue}/>
+                       </div>
                      </template>
                      <template if:true={recordselected}>
-                        <span class="slds-pill slds-pill_link fullWidth slds-input slds-combobox__input"> 
-                           <a href="javascript:void(0);" 
-                              class="slds-pill__action slds-p-left_x-small" title={selectedValue}>
-                              <lightning-icon icon-name={iconname} size="x-small"></lightning-icon>
-                              <span class="slds-pill__label slds-p-left_x-small">{selectedValue}</span>
-                           </a>
-                           <button onclick={clearSelection}
-                           class="slds-button slds-button_icon slds-button_icon slds-pill__remove" 
-                           title="Remove">
-                           <lightning-icon icon-name="utility:close" size="small" 
-                                       alternative-text="Press delete or backspace to remove"></lightning-icon>
-                              <span class="slds-assistive-text" >Remove</span>
-                           </button>
-                        </span>
+                       <label class="slds-form-element__label" for="text-input-id-1">
+                       <abbr class="slds-required" title="required">* </abbr>{inputLabel}</label>
+                       <span class="slds-pill slds-pill_link fullWidth slds-input slds-combobox__input" style="padding-right:0;"> 
+                          <a href="javascript:void(0);" 
+                             class="slds-pill__action" title={selectedValue} style="padding:3px;">
+                             <lightning-icon icon-name={iconName} size="small"></lightning-icon>
+                             <span class="slds-pill__label slds-p-left_x-small" style="position:relative; top:1px;">{selectedValue}</span>
+                          </a>
+
+                       </span>
+                       <button onclick={clearSelection}
+                          class="slds-button slds-button_icon slds-button_icon slds-pill__remove" 
+                          title="Remove"
+                          style="position: absolute; bottom: 9px; right: 6px;">
+                          <lightning-icon icon-name="utility:close" size="small" 
+                                      alternative-text="Press delete or backspace to remove"></lightning-icon>
+                             <span class="slds-assistive-text" >Remove</span>
+                       </button>
                      </template>
                   </div>
                   <template if:true={recordsList}>
@@ -32,10 +40,11 @@
                            <ul class="slds-listbox slds-listbox_vertical" role="presentation">
                               <template for:each={recordsList} for:item="item">
                                  <li key={item.Id} role="presentation" class="slds-listbox__item">
-                                    <div class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small" role="option"
-                                       data-itemid = {item.Id} data-itemname={item.Name} onclick={setSelectedValue}>
+                                    <div class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small itemSelection" role="option"
+                                       data-itemid = {item.Id} data-itemname={item.Name} onclick={setSelectedValue} onkeyup={lookupKeyboardNavigation} tabindex="0">
+                                       <lightning-icon class="slds-m-right_x-small" icon-name={iconName} size="x-small" data-itemid = {item.Id} data-itemname={item.Name}></lightning-icon> 
                                        <span role="menuitem" tabindex="-1" data-itemid = {item.Id} data-itemname={item.Name}>
-                                          <lightning-icon icon-name={iconname} size="x-small" data-itemid = {item.Id} data-itemname={item.Name}></lightning-icon> {item.Name}
+                                          {item.Name}
                                        </span>
                                     </div>
                                  </li>

--- a/force-app/main/default/lwc/lookupLwc/lookupLwc.js
+++ b/force-app/main/default/lwc/lookupLwc/lookupLwc.js
@@ -12,11 +12,18 @@ export default class LookupLwc extends LightningElement {
     recordselected = false;
     @api
     iconname;
+    
     //Method to query data after typing search term
     onKeyChange(event) {
-        this.selectedValue = event.target.value;
+        if(event.keyCode === 38 || event.keyCode === 40){
+            this.lookupKeyboardNavigation(event);
+            return;
+        }
+
+        this.selectedValue = this.template.querySelector('.lookupInput').value;
         getRecordsByName({objectName : this.objectname, searchFor : this.selectedValue})
             .then(result => {
+                this.selectedValue = this.template.querySelector('.lookupInput').value;
                 this.recordsList = result;
             })
             .catch(error => {
@@ -47,5 +54,44 @@ export default class LookupLwc extends LightningElement {
             } 
         });
         this.dispatchEvent(selectedEvent);
+    }
+
+    //keyboard keycodes:
+        //up = 38
+        //down = 40
+        //enter = 13
+    lookupKeyboardNavigation(event){
+        if(event.keyCode == 13){
+            this.firstTimeKeyboardNavigation = true;
+            this.setSelectedValue(event);
+            return;
+        } 
+
+        var itemSelected = this.template.querySelectorAll('.itemSelection');
+
+        var keyUp = event.keyCode === 38 ? true : false;
+        var keyDown = event.keyCode === 40 ? true : false;
+        if(keyUp || keyDown){     
+            if(this.firstTimeKeyboardNavigation){
+                this.indexFocusOn = keyUp ? itemSelected.length - 1 : 0;
+                this.firstTimeKeyboardNavigation = false;
+            } else if(this.indexFocusOn === 0 && keyUp){
+                this.indexFocusOn = itemSelected.length - 1;
+            } else if(this.indexFocusOn === itemSelected.length - 1 && keyDown){
+                this.indexFocusOn = 0;
+            } else {
+                this.indexFocusOn = keyUp ? this.indexFocusOn - 1  : this.indexFocusOn + 1;
+            }
+
+            itemSelected[this.indexFocusOn].focus();
+            return;
+        }
+
+        this.firstTimeKeyboardNavigation = true;
+        let lookupInput = this.template.querySelector('.lookupInput');
+        this.selectedValue = lookupInput.value + event.charCode;
+        lookupInput.selectionStart = lookupInput.value.length;
+        lookupInput.focus();
+        this.onKeyChange(event);
     }
 }


### PR DESCRIPTION
Hello, I have implemented your lookup and have added a new functionality using the keycode.

The idea is to be able to use only the keyboard instead of mouse+keyboard:

keyboard keycodes:
        up = 38
        down = 40
        enter = 13

 **lookupKeyboardNavigation**  methods is in charge of handle the events that comes from onKeyChange method.

**Bug**: I have updated the value of the variable selectedValue. If you use the event.target.value as a value after multiple callouts to database, the async js will make the value to be override and will inconsistently display wrong information.

**Solution**: Use querySelector to get the value before and after the callout to the database.

**html**
Label added - There´s a new @api variable
tabindex="0" is required for the navigation

Thanks!